### PR TITLE
Cli fixes and --name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Options:
   --normalize [bool]           normalize icons by scaling them to the height of the highest icon
   -r, --round [bool]           setup the SVG path rounding [10e12]
   --selector <value>           use a CSS selector instead of 'tag + prefix' (default: null)
-  -t, --tag <value>            CSS base tag for icons (default: i)
+  --tag <value>                CSS base tag for icons (default: i)
   -u, --fonts-url <value>      public url to the fonts directory (used in the generated CSS)
   --debug                      display errors stack trace (default: false)
   --silent                     run with no logs (default: false)

--- a/README.md
+++ b/README.md
@@ -33,17 +33,23 @@ Usage: fantasticon [options] [input-dir]
 
 Options:
   -V, --version                output the version number
-  -c, --config <value>         custom config path (default: .fantasticonrc | fantasticonrc | .fantasticonrc.json | fantasticonrc.json | .fantasticonrc.js | fantasticonrc.js)
+  -c, --config <value>         custom config path (default: .fantasticonrc | fantasticonrc | .fantasticonrc.json |
+                               fantasticonrc.json | .fantasticonrc.js | fantasticonrc.js)
   -o, --output <value>         specify output directory
-  -t, --font-types <value...>  specify font formats to generate (default: eot, woff2, woff, available: eot, woff2, woff, ttf, svg)
-  -g --asset-types <value...>  specify other asset types to generate (default: css, html, json, ts, available: css, html, json, ts)
-  -h, --font-height <value>    the output font height (icons will be scaled so the highest has this height) (default: 300)
+  -n, --name <value>           base name of the font set used both as default asset name and classname prefix
+                               (default: icons)
+  -t, --font-types <value...>  specify font formats to generate (default: eot, woff2, woff, available: eot, woff2,
+                               woff, ttf, svg)
+  -g --asset-types <value...>  specify other asset types to generate (default: css, html, json, ts, available:
+                               css, html, json, ts)
+  -h, --font-height <value>    the output font height (icons will be scaled so the highest has this height)
+                               (default: 300)
   --descent <value>            the font descent
-  -n, --normalize              normalize icons by scaling them to the height of the highest icon
-  -r, --round                  setup the SVG path rounding [10e12]
+  --normalize [bool]           normalize icons by scaling them to the height of the highest icon
+  -r, --round [bool]           setup the SVG path rounding [10e12]
   --selector <value>           use a CSS selector instead of 'tag + prefix' (default: null)
-  -t, --tag <value>            CSS base tag for icons (default: "i")
-  -u, --fonts-url <value>      public url to the fonts directory (used in the generated CSS) (default: "icon")
+  -t, --tag <value>            CSS base tag for icons (default: i)
+  -u, --fonts-url <value>      public url to the fonts directory (used in the generated CSS)
   --debug                      display errors stack trace (default: false)
   --silent                     run with no logs (default: false)
   --help                       display help for command

--- a/README.md
+++ b/README.md
@@ -29,21 +29,16 @@ fantasticon my-icons/*.svg -o icon-dist
 ### Command-line
 
 ```bash
-Usage: fantasticon [options] [input-dir]
+Usage: fantasticon [options] [inputDir]
 
 Options:
   -V, --version                output the version number
-  -c, --config <value>         custom config path (default: .fantasticonrc | fantasticonrc | .fantasticonrc.json |
-                               fantasticonrc.json | .fantasticonrc.js | fantasticonrc.js)
+  -c, --config <value>         custom config path (default: .fantasticonrc | fantasticonrc | .fantasticonrc.json | fantasticonrc.json | .fantasticonrc.js | fantasticonrc.js)
   -o, --output <value>         specify output directory
-  -n, --name <value>           base name of the font set used both as default asset name and classname prefix
-                               (default: icons)
-  -t, --font-types <value...>  specify font formats to generate (default: eot, woff2, woff, available: eot, woff2,
-                               woff, ttf, svg)
-  -g --asset-types <value...>  specify other asset types to generate (default: css, html, json, ts, available:
-                               css, html, json, ts)
-  -h, --font-height <value>    the output font height (icons will be scaled so the highest has this height)
-                               (default: 300)
+  -n, --name <value>           base name of the font set used both as default asset name and classname prefix (default: icons)
+  -t, --font-types <value...>  specify font formats to generate (default: eot, woff2, woff, available: eot, woff2, woff, ttf, svg)
+  -g --asset-types <value...>  specify other asset types to generate (default: css, html, json, ts, available: css, html, json, ts)
+  -h, --font-height <value>    the output font height (icons will be scaled so the highest has this height) (default: 300)
   --descent <value>            the font descent
   --normalize [bool]           normalize icons by scaling them to the height of the highest icon
   -r, --round [bool]           setup the SVG path rounding [10e12]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "fantasticon",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.1",
         "cli-color": "^2.0.0",
-        "commander": "^6.1.0",
+        "commander": "^6.2.0",
         "glob": "^7.1.6",
         "handlebars": "^4.7.6",
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "change-case": "^4.1.1",
     "cli-color": "^2.0.0",
-    "commander": "^6.1.0",
+    "commander": "^6.2.0",
     "glob": "^7.1.6",
     "handlebars": "^4.7.6",
     "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fantasticon",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "lib/index.js",
   "bin": {
     "fantasticon": "bin/fantasticon"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,19 @@ const printList = (available: { [key: string]: string }, defaults: string[]) =>
     available
   ).join(', ')})`;
 
+const printDefaultValue = (value: any) => {
+  let printVal = String(value);
+
+  if (typeof value === 'undefined') {
+    return '';
+  }
+
+  return ` (default: ${printVal})`;
+};
+
+const printDefaultOption = (key: string) =>
+  printDefaultValue(DEFAULT_OPTIONS[key]);
+
 const printConfigPaths = () => DEFAULT_FILEPATHS.join(' | ');
 
 const config = () => {
@@ -58,8 +71,8 @@ const config = () => {
 
     .option(
       '-n, --name <value>',
-      'base name of the font set used both as default asset name and classname prefix',
-      DEFAULT_OPTIONS.name
+      'base name of the font set used both as default asset name and classname prefix' +
+        printDefaultOption('name')
     )
 
     .option(
@@ -76,40 +89,42 @@ const config = () => {
 
     .option(
       '-h, --font-height <value>',
-      'the output font height (icons will be scaled so the highest has this height)',
-      DEFAULT_OPTIONS.fontHeight as any
+      'the output font height (icons will be scaled so the highest has this height)' +
+        printDefaultOption('fontHeight')
     )
 
     .option(
       '--descent <value>',
-      'the font descent',
-      DEFAULT_OPTIONS.descent as any
+      'the font descent' + printDefaultOption('descent' as any)
     )
 
     .option(
       '--normalize [bool]',
-      'normalize icons by scaling them to the height of the highest icon',
-      DEFAULT_OPTIONS.normalize
+      'normalize icons by scaling them to the height of the highest icon' +
+        printDefaultOption('normalize')
     )
 
     .option('-r, --round [bool]', 'setup the SVG path rounding [10e12]')
 
     .option(
       '--selector <value>',
-      "use a CSS selector instead of 'tag + prefix'",
-      DEFAULT_OPTIONS.selector
+      "use a CSS selector instead of 'tag + prefix'" +
+        printDefaultOption('selector')
     )
 
-    .option('-t, --tag <value>', 'CSS base tag for icons', DEFAULT_OPTIONS.tag)
+    .option(
+      '-t, --tag <value>',
+      'CSS base tag for icons' + printDefaultOption('tag')
+    )
 
     .option(
       '-u, --fonts-url <value>',
       'public url to the fonts directory (used in the generated CSS)'
     )
 
-    .option('--debug', 'display errors stack trace', false)
+    .option('--debug', 'display errors stack trace' + printDefaultValue(false))
 
-    .option('--silent', 'run with no logs', false);
+    .option('--silent', 'run with no logs' + printDefaultValue(false));
 };
 
 const buildOptions = async (cmd: commander.Command, loadedConfig = {}) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -60,7 +60,7 @@ const config = () => {
 
     .version(version)
 
-    .arguments('[inputDir]')
+    .arguments('[input-dir]')
 
     .option(
       '-c, --config <value>',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -113,7 +113,7 @@ const config = () => {
     )
 
     .option(
-      '-t, --tag <value>',
+      '--tag <value>',
       'CSS base tag for icons' + printDefaultOption('tag')
     )
 

--- a/src/core/config-parser.ts
+++ b/src/core/config-parser.ts
@@ -17,7 +17,7 @@ const CONFIG_VALIDATORS: {
 } = {
   inputDir: [optional(parseString), optional(parseDir)],
   outputDir: [optional(parseString), optional(parseDir)],
-  name: [parseString],
+  name: [optional(parseString)],
   fontTypes: [listMembersParser(Object.values(FontAssetType))],
   assetTypes: [listMembersParser(Object.values(OtherAssetType))],
   formatOptions: [],


### PR DESCRIPTION
* Use `storeOptionsAsProperties` and `opts` in commander to be able to specify `--name` options without conflicts
* Avoid passing actual defaults, instead print default values as part of the command description, to avoid overriding values from a specified config file
* Remove -t shortcut for tag