### PR TITLE
Codepoints in runner result

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ module.exports = {
 ```js
 import { generateFonts } from 'fantasticon';
 
-generateFonts().then('Done');
+generateFonts().then(results => console.log('Done', results));
 ```
 
 #### Options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fantasticon",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "lib/index.js",
   "bin": {
     "fantasticon": "bin/fantasticon"

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -6,6 +6,8 @@ import {
   AssetsMap,
   WriteResults
 } from '../utils/assets';
+import { CodepointsMap } from '../utils/codepoints';
+import { getGeneratorOptions } from '../generators/generator-options';
 import { GeneratedAssets } from '../generators/generate-assets';
 import { parseConfig } from './config-parser';
 import { generateAssets } from '../generators';
@@ -15,6 +17,7 @@ export interface RunnerResults {
   writeResults: WriteResults;
   assetsIn: AssetsMap;
   assetsOut: GeneratedAssets;
+  codepoints: CodepointsMap;
 }
 
 export const sanitiseOptions = (userOptions: any) =>
@@ -39,8 +42,16 @@ export const generateFonts = async (
   }
 
   const assetsIn = await loadAssets(options.inputDir);
-  const assetsOut = await generateAssets(assetsIn, options);
+  const generatorOptions = getGeneratorOptions(options, assetsIn);
+  const assetsOut = await generateAssets(generatorOptions);
   const writeResults = outputDir ? await writeAssets(assetsOut, options) : [];
+  const { codepoints } = generatorOptions;
 
-  return { options, assetsIn, assetsOut, writeResults };
+  return {
+    options,
+    assetsIn,
+    assetsOut,
+    writeResults,
+    codepoints
+  };
 };

--- a/src/generators/__tests__/generate-assets.ts
+++ b/src/generators/__tests__/generate-assets.ts
@@ -1,16 +1,8 @@
-import { FontAssetType, OtherAssetType, AssetType } from '../../types/misc';
-import { RunnerOptions } from '../../types/runner';
+import { AssetType, FontAssetType, OtherAssetType } from '../../types/misc';
+import { FontGeneratorOptions } from '../../types/generator';
 import { AssetsMap } from '../../utils/assets';
 import { generateAssets } from '../generate-assets';
-import { getCodepoints } from '../../utils/codepoints';
-import { getGeneratorOptions } from '../generator-options';
 import generators from '../asset-types';
-
-const getCodepointsMock = (getCodepoints as any) as jest.Mock;
-
-jest.mock('../../utils/codepoints', () => ({
-  getCodepoints: jest.fn(() => ({ __mock: 'codepoint__' }))
-}));
 
 jest.mock('../asset-types', () => {
   const mockResult = (type: string) => `::${type}::`;
@@ -45,17 +37,13 @@ describe('Generate assets', () => {
     for (const gen of Object.values(generators)) {
       ((gen.generate as unknown) as jest.Mock).mockClear();
     }
-
-    getCodepointsMock.mockClear();
   });
 
   test('`generateAssets` correctly generates and returns assets specified by the merged `fontTypes` and `assetTypes` option', async () => {
     const fontTypes = cast<FontAssetType[]>(['a']);
     const assetTypes = cast<OtherAssetType[]>(['c']);
-    const assets = cast<AssetsMap>({ __mock: 'assetsMap__' });
     const result = await generateAssets(
-      assets,
-      cast<RunnerOptions>({ fontTypes, assetTypes })
+      cast<FontGeneratorOptions>({ fontTypes, assetTypes })
     );
 
     expect(result).toEqual({ a: '::a::', c: '::c::' });
@@ -64,34 +52,25 @@ describe('Generate assets', () => {
   test('`generateAssets` calls necessary generator functions with correct argugments and only once, and with correctly generated codepoints', async () => {
     const fontTypes = cast<AssetType[]>(['b', 'd']);
     const assets = cast<AssetsMap>({ __mock: 'assetsMap__' });
-    const codepointsIn = { __mock: '::codepoint-in::' };
-    const codepointsOut = { __mock: '::codepoint-out::' };
-    const options = cast<RunnerOptions>({
-      fontTypes,
+    const codepoints = { __mock: '::codepoint::' };
+    const options = cast<FontGeneratorOptions>({
       assetTypes: [],
-      codepoints: codepointsIn
+      codepoints,
+      fontTypes,
+      assets
     });
-    const genOptions = {
-      ...getGeneratorOptions(options, assets),
-      codepoints: codepointsOut
-    };
 
-    getCodepointsMock.mockImplementationOnce(() => codepointsOut);
-
-    await generateAssets(assets, options);
-
-    expect(getCodepointsMock).toHaveBeenCalledTimes(1);
-    expect(getCodepointsMock).toHaveBeenCalledWith(assets, codepointsIn);
+    await generateAssets(options);
 
     expect(getGeneratorFn('a')).toHaveBeenCalledTimes(1);
-    expect(getGeneratorFn('a')).toHaveBeenCalledWith(genOptions, null);
+    expect(getGeneratorFn('a')).toHaveBeenCalledWith(options, null);
 
     expect(getGeneratorFn('b')).toHaveBeenCalledTimes(1);
-    expect(getGeneratorFn('b')).toHaveBeenCalledWith(genOptions, '::a::');
+    expect(getGeneratorFn('b')).toHaveBeenCalledWith(options, '::a::');
 
     expect(getGeneratorFn('c')).not.toHaveBeenCalled();
 
     expect(getGeneratorFn('d')).toHaveBeenCalledTimes(1);
-    expect(getGeneratorFn('d')).toHaveBeenCalledWith(genOptions, null);
+    expect(getGeneratorFn('d')).toHaveBeenCalledWith(options, null);
   });
 });

--- a/src/generators/generate-assets.ts
+++ b/src/generators/generate-assets.ts
@@ -1,8 +1,5 @@
 import { AssetType, FontAssetType, OtherAssetType } from '../types/misc';
-import { RunnerOptions } from '../types/runner';
-import { getCodepoints } from '../utils/codepoints';
-import { AssetsMap } from '../utils/assets';
-import { getGeneratorOptions } from './generator-options';
+import { FontGeneratorOptions } from '../types/generator';
 import generators from './asset-types';
 
 export type GeneratedAssets = {
@@ -10,13 +7,9 @@ export type GeneratedAssets = {
 };
 
 export const generateAssets = async (
-  assets: AssetsMap,
-  options: RunnerOptions
+  options: FontGeneratorOptions
 ): Promise<GeneratedAssets> => {
-  options.codepoints = { ...getCodepoints(assets, options.codepoints) };
-
   const generated: GeneratedAssets = {};
-  const generatorOptions = getGeneratorOptions(options, assets);
   const generateTypes = [...options.fontTypes, ...options.assetTypes];
 
   const generateAsset = async (type: AssetType) => {
@@ -32,7 +25,7 @@ export const generateAssets = async (
     }
 
     return (generated[type] = await generator.generate(
-      generatorOptions,
+      options,
       dependsOn ? generated[dependsOn] : null
     ));
   };

--- a/src/generators/generator-options.ts
+++ b/src/generators/generator-options.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_OPTIONS } from '../constants';
 import { RunnerOptions } from '../types/runner';
+import { getCodepoints } from '../utils/codepoints';
 import { FontGeneratorOptions } from '../types/generator';
 import { AssetType, ASSET_TYPES } from '../types/misc';
 import { AssetsMap } from '../utils/assets';
@@ -9,6 +10,7 @@ export const getGeneratorOptions = (
   assets: AssetsMap
 ): FontGeneratorOptions => ({
   ...options,
+  codepoints: getCodepoints(assets, options.codepoints),
   formatOptions: prefillOptions(
     options.formatOptions,
     DEFAULT_OPTIONS.formatOptions

--- a/src/utils/codepoints.ts
+++ b/src/utils/codepoints.ts
@@ -8,7 +8,6 @@ export const getCodepoints = (
   predefined: CodepointsMap = {},
   start = DEFAULT_START_CODEPOINT
 ): CodepointsMap => {
-  2;
   const out: CodepointsMap = {};
   const used = Object.values(predefined);
   let current: number = start;

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,0 @@
-import { generateFonts } from './src';
-
-generateFonts({
-  inputDir: '/Users/tancreditrugenberger/Desktop/Fantasticon/test/icons',
-  outputDir: '/Users/tancreditrugenberger/Desktop/Fantasticon/test/dist'
-}).then(results => console.log(results.codepoints));

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,6 @@
+import { generateFonts } from './src';
+
+generateFonts({
+  inputDir: '/Users/tancreditrugenberger/Desktop/Fantasticon/test/icons',
+  outputDir: '/Users/tancreditrugenberger/Desktop/Fantasticon/test/dist'
+}).then(results => console.log(results.codepoints));


### PR DESCRIPTION
* Make output `codepoints` available in the `generateFonts` resolved result