### PR TITLE
fix(get-generator-options): templates prefills defaults that don't exist

### DIFF
--- a/src/generators/generator-options.ts
+++ b/src/generators/generator-options.ts
@@ -18,7 +18,9 @@ export const getGeneratorOptions = (
     assetType => DEFAULT_OPTIONS.formatOptions[assetType] || {}
   ),
   templates: prefillOptions<AssetType, string>(
-    Object.values(OtherAssetType),
+    Object.values(OtherAssetType).filter(assetType =>
+      ['css', 'html', 'sass', 'scss'].includes(assetType)
+    ),
     options.templates,
     assetType => getDefaultTemplatePath(assetType)
   ),


### PR DESCRIPTION
The way it was there would be a `json.hbs` and `ts.hbs` required, but these do not exist and unlileley ever will :wink:
