### PR TITLE
Small format options and default template path fixes

### DIFF
--- a/src/generators/generator-options.ts
+++ b/src/generators/generator-options.ts
@@ -1,9 +1,9 @@
+import { resolve } from 'path';
 import { DEFAULT_OPTIONS } from '../constants';
 import { FormatOptions, RunnerOptions } from '../types/runner';
 import { getCodepoints } from '../utils/codepoints';
 import { FontGeneratorOptions } from '../types/generator';
 import { AssetType, OtherAssetType, ASSET_TYPES } from '../types/misc';
-import { getDefaultTemplatePath } from '../utils/template';
 import { AssetsMap } from '../utils/assets';
 
 export const getGeneratorOptions = (
@@ -20,10 +20,11 @@ export const getGeneratorOptions = (
   templates: prefillOptions<AssetType, string>(
     Object.values(OtherAssetType),
     options.templates,
-    assetType => getDefaultTemplatePath(assetType)
+    assetType => resolve(__dirname, `../../templates/${assetType}.hbs`)
   ),
   assets
 });
+
 export const prefillOptions = <K extends AssetType, T, O = { [key in K]: T }>(
   keys: K[],
   userOptions: { [key in K]?: T } = {},

--- a/src/generators/generator-options.ts
+++ b/src/generators/generator-options.ts
@@ -18,7 +18,9 @@ export const getGeneratorOptions = (
     assetType => DEFAULT_OPTIONS.formatOptions[assetType] || {}
   ),
   templates: prefillOptions<AssetType, string>(
-    Object.values(OtherAssetType),
+    Object.values(OtherAssetType).filter(assetType =>
+      ['css', 'html', 'sass', 'scss'].includes(assetType)
+    ),
     options.templates,
     assetType => resolve(__dirname, `../../templates/${assetType}.hbs`)
   ),

--- a/src/types/runner.ts
+++ b/src/types/runner.ts
@@ -23,6 +23,8 @@ export interface FormatOptions {
     | 'log'
   >;
   css?: any;
+  sass?: any;
+  scss?: any;
   html?: any;
   json?: {
     indent?: number;

--- a/src/utils/__tests__/template.ts
+++ b/src/utils/__tests__/template.ts
@@ -1,5 +1,5 @@
 import Handlebars from 'handlebars';
-import { renderTemplate, getDefaultTemplatePath } from '../template';
+import { renderTemplate } from '../template';
 import { readFile } from '../fs-async';
 
 const readFileMock = (readFile as any) as jest.Mock;
@@ -39,14 +39,5 @@ describe('Template utilities', () => {
 
     expect(templateFn).toHaveBeenCalledTimes(1);
     expect(templateFn).toHaveBeenCalledWith(context, options);
-  });
-
-  test('`getDefaultTemplatePath` generates expected path', () => {
-    expect(getDefaultTemplatePath('foo' as any)).toBe(
-      '/root/project/templates/foo.hbs'
-    );
-    expect(getDefaultTemplatePath('bar' as any)).toBe(
-      '/root/project/templates/bar.hbs'
-    );
   });
 });

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -1,9 +1,6 @@
 import Handlebars from 'handlebars';
 import { resolve, isAbsolute } from 'path';
-import { AssetType } from '../types/misc';
 import { readFile } from './fs-async';
-
-const TEMPLATES_PATH = '../../templates';
 
 export type CompileOptions = {
   helpers?: { [key: string]: (...args: any[]) => string };
@@ -21,6 +18,3 @@ export const renderTemplate = async (
 
   return Handlebars.compile(template)(context, options);
 };
-
-export const getDefaultTemplatePath = (assetType: AssetType) =>
-  resolve(__dirname, TEMPLATES_PATH, `${assetType}.hbs`);


### PR DESCRIPTION
- add missing properties to FormatOptions interface
- prevent not existing templates to be added to default options
- simplify getting default template path
