### PR TITLE
Enforce LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
On Windows `autocrlf` is true and this resulted in CRLF which prettier changed. With this patch, LF will be used regardless of OS or git settings.