### PR TITLE
Add rimraf so that build is cross-platform.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "build": "rm -rf lib && tsc --project ./tsconfig.json",
+    "build": "rimraf lib && tsc --project ./tsconfig.json",
     "watch": "tsc --project ./tsconfig.json --watch",
     "lint": "prettier --check ."
   },
@@ -60,6 +60,7 @@
     "jest": "^26.6.3",
     "mock-fs": "^4.13.0",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
     "semantic-release": "^17.3.0",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"


### PR DESCRIPTION
Note that this didn't fail on CI because `rm` is present through Git for Windows. But on native Windows cmd, `rm` isn't available.