### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,13 @@ on:
   push:
     branches: [master]
 
+env:
+  FORCE_COLOR: 2
+  NODE: 14.x
+
 jobs:
   release:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: "!contains(github.event.head_commit.message, 'skip ci') && github.repository == 'tancredi/fantasticon'"
     name: Release
 
     runs-on: ubuntu-18.04
@@ -15,9 +19,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: '${{ env.NODE }}'
+      - name: Set up npm cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+            ${{ runner.os }}-node-v${{ env.NODE }}-
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,19 +1,31 @@
 name: Test
 
-on: [push, pull_request_target]
+on: [push, pull_request]
+
+env:
+  FORCE_COLOR: 2
 
 jobs:
   lint:
     name: Lint
+    env:
+      NODE: 14.x
 
     runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14
-      - run: npm install
+          node-version: '${{ env.NODE }}'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+            ${{ runner.os }}-node-v${{ env.NODE }}-
+      - run: npm ci
       - run: npm run lint
 
   test:
@@ -23,16 +35,28 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-10.15, ubuntu-18.04, windows-2019]
-        node-version: [10.x, 12.x, 15.x]
+        node: [10.x, 12.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
+          node-version: ${{ matrix.node }}
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-v${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-v${{ matrix.node }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+            ${{ runner.os }}-node-v${{ matrix.node }}-
+      - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
* change on event to `pull_request`
* specify `FORCE_COLOR: 2`
* update to `actions/setup-node@v2`
* use `npm ci`
* add OS-dependent caching
* skip the release workflow if the repo isn't `tancredi/fantasticon`
* add `fail-fast: false`

Preview: https://github.com/XhmikosR/fantasticon/runs/1697356461