### PR TITLE
package.json: specify the files to include in the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.github
-src
-tsconfig.json
-lib/**/__mocks__/**
-lib/**/__tests__/**

--- a/package.json
+++ b/package.json
@@ -72,5 +72,11 @@
   },
   "engines": {
     "node": ">= 10.0.0"
-  }
+  },
+  "files": [
+    "bin/fantasticon",
+    "lib/**/*.{js,ts,map}",
+    "!lib/**/{__mocks__,__tests__}/",
+    "templates/*.hbs"
+  ]
 }


### PR DESCRIPTION
This is a more explicit way than using a .npmignore file and should now properly skip the tests and mocks folders.

Before:

```
npm notice === Tarball Details ===
npm notice name:          fantasticon
npm notice version:       0.0.0
npm notice filename:      fantasticon-0.0.0.tgz
npm notice package size:  59.3 kB
npm notice unpacked size: 376.1 kB
npm notice total files:   194
npm notice
fantasticon-0.0.0.tgz
```

After:

```
npm notice === Tarball Details ===
npm notice name:          fantasticon
npm notice version:       0.0.0
npm notice filename:      fantasticon-0.0.0.tgz
npm notice package size:  31.1 kB
npm notice unpacked size: 156.4 kB
npm notice total files:   113
npm notice
fantasticon-0.0.0.tgz
```