### PR TITLE
Replace lodash with native methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1052,12 +1052,6 @@
         "pretty-format": "^26.0.0"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "commander": "^7.0.0",
     "glob": "^7.1.6",
     "handlebars": "^4.7.6",
-    "lodash": "^4.17.20",
     "slugify": "^1.4.6",
     "svg2ttf": "^5.0.0",
     "svgicons2svgfont": "^9.1.1",
@@ -53,7 +52,6 @@
   "devDependencies": {
     "@types/cli-color": "^2.0.0",
     "@types/glob": "^7.1.3",
-    "@types/lodash": "^4.14.168",
     "@types/node": "^14.14.25",
     "@types/svg2ttf": "^5.0.0",
     "@types/svgicons2svgfont": "^9.1.0",

--- a/src/__mocks__/path.ts
+++ b/src/__mocks__/path.ts
@@ -1,4 +1,3 @@
-import startsWith from 'lodash/startsWith';
 const _path = jest.requireActual('path');
 const _relative = _path.relative;
 
@@ -11,14 +10,14 @@ const resolve = (...paths: string[]) => {
     path = !path ? normalise(cur) : _path.join(path, normalise(cur));
   }
 
-  if (startsWith(path, projectDir)) {
+  if (path.startsWith(projectDir)) {
     path = _path.join('/root/project', path.substr(projectDir.length));
-  } else if (startsWith(path, '/') && !startsWith(path, '/root')) {
+  } else if (path.startsWith('/') && !path.startsWith('/root')) {
     path = _path.join('/root/', path.substr(1));
   } else {
-    if (startsWith(path, './')) {
+    if (path.startsWith('./')) {
       path = _path.join('/root/project/', path.substr(2));
-    } else if (!startsWith(path, '/')) {
+    } else if (!path.startsWith('/')) {
       path = _path.join('/root/project/', path);
     }
   }
@@ -52,6 +51,6 @@ const join = (...segments: string[]): string => {
 
 const normalise = (path: string) => path.replace(/\\/g, '/');
 
-const isAbsolute = (path: string) => startsWith(path, '/root');
+const isAbsolute = (path: string) => path.startsWith('/root');
 
 module.exports = { resolve, relative, join, isAbsolute };

--- a/src/core/config-parser.ts
+++ b/src/core/config-parser.ts
@@ -1,6 +1,5 @@
 import { RunnerOptions } from '../types/runner';
 import { DEFAULT_OPTIONS } from '../constants';
-import uniq from 'lodash/uniq';
 import {
   parseDir,
   parseString,
@@ -37,9 +36,11 @@ const CONFIG_VALIDATORS: {
 export const parseConfig = async (input: object = {}) => {
   const options = { ...DEFAULT_OPTIONS, ...input };
   const out = {};
-  const allKeys = [...Object.keys(options), ...Object.keys(CONFIG_VALIDATORS)];
+  const allkeys = [
+    ...new Set([...Object.keys(options), ...Object.keys(CONFIG_VALIDATORS)])
+  ];
 
-  for (const key of uniq(allKeys)) {
+  for (const key of allkeys) {
     const validators = CONFIG_VALIDATORS[key];
 
     if (!validators) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "sourceMap": true,
+    "target": "ES6",
     "types": ["node", "jest"]
   },
   "typeRoots": ["node_modules/@types"],


### PR DESCRIPTION
Draft until the other PRs are sorted and also because I had to change the TS target.

I'll check if there's any other way without changing the target.

TODO:

- [ ] Make sure everything works because the native methods aren't 1-to-1 replacement when it comes to null etc

EDIT: So it seems there are some workarounds with `downlevelIteration` etc, but I'm not sure it's worth it. Personally I think we should change the target to be in sync with the `engines` version and/or make it a major version bump.

Not super familiar with TS, so I'd leave this to you @tancredi :)