### PR TITLE
Allow use custom extensions

### DIFF
--- a/src/core/__tests__/config-parser.ts
+++ b/src/core/__tests__/config-parser.ts
@@ -76,11 +76,6 @@ describe('Config parser', () => {
       'fontTypes',
       'x is not valid - accepted values are: a, b'
     );
-    await testError(
-      { assetTypes: ['x'] },
-      'assetTypes',
-      'x is not valid - accepted values are: c, d'
-    );
     await testError({ descent: 'a' }, 'descent', 'a is not a valid number');
     await testError(
       { normalize: null },

--- a/src/core/config-parser.ts
+++ b/src/core/config-parser.ts
@@ -19,7 +19,7 @@ const CONFIG_VALIDATORS: {
   outputDir: [optional(parseString), optional(parseDir)],
   name: [optional(parseString)],
   fontTypes: [listMembersParser(Object.values(FontAssetType))],
-  assetTypes: [listMembersParser(Object.values(OtherAssetType))],
+  assetTypes: [],
   formatOptions: [],
   pathOptions: [],
   templates: [],

--- a/src/generators/asset-types/custom.ts
+++ b/src/generators/asset-types/custom.ts
@@ -1,0 +1,17 @@
+import { FontGenerator } from '../../types/generator';
+import { FontAssetType } from '../../types/misc';
+import { renderTemplate } from '../../utils/template';
+import { renderSrcAttribute } from '../../utils/css';
+
+const generator: FontGenerator<Buffer> = {
+  dependsOn: FontAssetType.SVG,
+
+  generate: (options, svg: Buffer, ext: string) => {
+    return renderTemplate(options.templates[ext] || options.templates.css, {
+      ...options,
+      fontSrc: renderSrcAttribute(options, svg)
+    });
+  }
+};
+
+export default generator;

--- a/src/generators/generate-assets.ts
+++ b/src/generators/generate-assets.ts
@@ -1,6 +1,7 @@
 import { AssetType, FontAssetType, OtherAssetType } from '../types/misc';
 import { FontGeneratorOptions } from '../types/generator';
 import generators from './asset-types';
+import custom from './asset-types/custom';
 
 export type GeneratedAssets = {
   [key in FontAssetType | OtherAssetType]?: string | Buffer;
@@ -12,26 +13,40 @@ export const generateAssets = async (
   const generated: GeneratedAssets = {};
   const generateTypes = [...options.fontTypes, ...options.assetTypes];
 
-  const generateAsset = async (type: AssetType) => {
-    if (generated[type]) {
-      return generated[type];
+  const generateAsset = async (type: AssetType | 'custom', ext: string) => {
+    if (generated[ext]) {
+      return generated[ext];
+    }
+    let generator;
+    let dependsOn;
+    if (type === 'custom') {
+      generator = custom;
+      dependsOn = custom.dependsOn;
+    } else {
+      generator = generators[type];
+      dependsOn = generator && 'dependsOn' in generator && generator.dependsOn;
+    }
+    const params =
+      [
+        options,
+        dependsOn
+          ? (generated[dependsOn] ?? (generated[dependsOn] = await generateAsset(dependsOn, ext)))
+          : null
+      ];
+    if (type === 'custom'){
+      params.push(ext)
     }
 
-    const generator = generators[type];
-    const dependsOn = 'dependsOn' in generator && generator.dependsOn;
-
-    if (dependsOn && !generated[dependsOn]) {
-      generated[dependsOn] = await generateAsset(dependsOn);
-    }
-
-    return (generated[type] = await generator.generate(
-      options,
-      dependsOn ? generated[dependsOn] : null
-    ));
+    return (generated[ext] = await generator.generate(...params));
   };
 
   for (const type of generateTypes) {
-    await generateAsset(type);
+    if (type in generators) {
+      await generateAsset(type, type);
+    } else {
+      await generateAsset('custom', type);
+    }
+
   }
 
   return generateTypes.reduce(

--- a/src/generators/generator-options.ts
+++ b/src/generators/generator-options.ts
@@ -23,11 +23,13 @@ export const getGeneratorOptions = (
     options.formatOptions,
     assetType => DEFAULT_OPTIONS.formatOptions[assetType] || {}
   ),
-  templates: prefillOptions<OtherAssetType, string>(
-    ASSET_TYPES_WITH_TEMPLATE,
-    options.templates,
-    assetType => join(TEMPLATES_DIR, `${assetType}.hbs`)
-  ),
+  templates: {
+    ...ASSET_TYPES_WITH_TEMPLATE.reduce((acc, assetType) => ({
+      ...acc,
+      [assetType]: join(TEMPLATES_DIR, `${assetType}.hbs`)
+    }), {}),
+    ...options.templates
+  },
   assets
 });
 
@@ -35,14 +37,16 @@ export const prefillOptions = <K extends AssetType, T, O = { [key in K]: T }>(
   keys: K[],
   userOptions: { [key in K]?: T } = {},
   getDefault: (type: K) => T
-) =>
-  keys.reduce(
+) => {
+  console.log(userOptions);
+  return keys.reduce(
     (cur = {}, type: K) => ({
       ...cur,
       [type]: mergeOptions(userOptions[type], getDefault(type))
     }),
     {}
   ) as O;
+};
 
 export const mergeOptions = <T>(input: T, defaultVal: T) => {
   if (typeof defaultVal === 'object') {

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -6,14 +6,15 @@ import { FormatOptions } from './format';
 export type FontGeneratorOptions = RunnerOptions & {
   assets: AssetsMap;
   formatOptions: FormatOptions;
-  templates: { [key in OtherAssetType]: string };
+  templates: { [key: string]: string };
 };
 
 export type Result = Promise<string | Buffer>;
 
 export type FontGeneratorFn<DependencyT> = (
   options: FontGeneratorOptions,
-  dependencyContent: DependencyT extends {} ? DependencyT : null
+  dependencyContent: DependencyT extends {} ? DependencyT : null,
+  ext?: string
 ) => Result;
 
 export type FontGenerator<DependencyT = void> = {

--- a/src/types/runner.ts
+++ b/src/types/runner.ts
@@ -20,7 +20,7 @@ export type RunnerOptionalOptions = {
   round: number;
   selector: string;
   tag: string;
-  templates: { [key in OtherAssetType]?: string };
+  templates: { [key: string]: string };
   prefix: string;
   fontsUrl: string;
 };


### PR DESCRIPTION
Add the ability to create custom CSS file extensions - useful when you want to split CSS main definition from class-names or use it with css-modules