### PR TITLE
Predictable builds

### DIFF
--- a/src/generators/asset-types/__tests__/ttf.ts
+++ b/src/generators/asset-types/__tests__/ttf.ts
@@ -25,15 +25,18 @@ describe('`TTF` font generator', () => {
     const result = await ttfGen.generate(mockOptions(), svg);
 
     expect(svg2ttf).toHaveBeenCalledTimes(1);
-    expect(svg2ttf).toHaveBeenCalledWith(svg, { __mock: 'options__' });
+    expect(svg2ttf).toHaveBeenCalledWith(svg, {
+      ts: null,
+      __mock: 'options__'
+    });
     expect(result).toEqual(Buffer.from(`::ttf(${svg})::`));
   });
 
-  test('passes correctly format options to `svg2ttf`', async () => {
+  test('passes correctly format options to `svg2ttf` and sets `ts` (timestamp) to `null` by default to avoid generating unnecessary diffs', async () => {
     const formatOptions = { foo: 'bar' };
     await ttfGen.generate(mockOptions(formatOptions), svg);
 
     expect(svg2ttf).toHaveBeenCalledTimes(1);
-    expect(svg2ttf.mock.calls[0][1]).toEqual(formatOptions);
+    expect(svg2ttf.mock.calls[0][1]).toEqual({ ts: null, ...formatOptions });
   });
 });

--- a/src/generators/asset-types/ttf.ts
+++ b/src/generators/asset-types/ttf.ts
@@ -6,7 +6,7 @@ const generator: FontGenerator<string> = {
   dependsOn: FontAssetType.SVG,
 
   async generate({ formatOptions }, svg) {
-    const font = svg2ttf(svg, formatOptions?.ttf);
+    const font = svg2ttf(svg, { ts: null, ...(formatOptions?.ttf || {}) });
     return Buffer.from(font.buffer);
   }
 };


### PR DESCRIPTION
Solves https://github.com/tancredi/fantasticon/issues/90

- Pass default `0` (timestamp) option to 'ttf' generator to avoid creating unnecessary builds