### PR TITLE
added support for specifying codepoints as hex strings

### DIFF
--- a/src/core/config-parser.ts
+++ b/src/core/config-parser.ts
@@ -6,6 +6,7 @@ import {
   parseBoolean,
   listMembersParser,
   parseNumeric,
+  parseCodepoints,
   optional,
   nullable
 } from '../utils/validation';
@@ -22,7 +23,7 @@ const CONFIG_VALIDATORS: {
   formatOptions: [],
   pathOptions: [],
   templates: [],
-  codepoints: [],
+  codepoints: [parseCodepoints],
   fontHeight: [optional(parseNumeric)],
   descent: [optional(parseNumeric)],
   normalize: [optional(parseBoolean)],

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,4 +1,5 @@
 import { checkPath } from './fs-async';
+import { CodepointsMap } from './codepoints';
 
 export const parseNumeric = (value: string) => {
   const out = Number(value);
@@ -36,6 +37,15 @@ export const listMembersParser = <T extends string>(allowedValues: T[]) => (
   }
 
   return values as T[];
+};
+
+export const parseCodepoints = (codepoints: Object): CodepointsMap => {
+  for (const key of Object.keys(codepoints)) {
+    if (typeof codepoints[key] === 'string') {
+      codepoints[key] = parseInt(codepoints[key], 16);
+    }
+  }
+  return codepoints as CodepointsMap;
 };
 
 export const removeUndefined = (object: Object) => {


### PR DESCRIPTION
The usual notation for codepoint map is hex, which is not compatible with json by default. This PR adds support for hex string values for codepoints which are then parsed into appropriate numeric values.

The same config file can use multiple notations interchangeably:
```
codepoints: {
  'arrow-out': 57344,
  'exclamation-circle':'\e00d',
  'arrow-down': '0xe01d'
}
```
