### PR TITLE
Configurable getIconId

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fantasticon my-icons -o icon-dist
 
 ### Command-line
 
-**Note:** Not all options can be specified through the command line - for `formatOptions`, `pathOptions` and `templates` use a [configuration file](#configuration-file) or the JavaScript API.
+**Note:** Not all options can be specified through the command line - for `formatOptions`, `pathOptions`, `getIconId` and `templates` use a [configuration file](#configuration-file) or the JavaScript API.
 
 ```
 Usage: fantasticon [options] [input-dir]
@@ -62,7 +62,7 @@ Options:
 
 ### Configuration file
 
-Some options (specifically, `formatOptions` and `pathOptions`) cannot be passed to the CLI directly.
+Some options (specifically, `formatOptions`, `pathOptions` and `getIconId`) cannot be passed to the CLI directly.
 
 To have more control and better readability, you can create a simple configuration file.
 
@@ -113,6 +113,10 @@ module.exports = {
     'chevron-right': 57345,
     'thumbs-up': 57358,
     'thumbs-down': 57359
+  },
+  // Customize generated icon IDs (unavailable with .json config file extension)
+  getIconId: (relativeIconPath, relativeInputDir) => {
+    /* ... */
   }
 };
 ```
@@ -185,6 +189,8 @@ And the generated icon IDs would be:
 | `social-twitter`       | `.icon.icon-social-twitter`  |
 | `symbol-chevron-left`  | `.icon.icon-chevron-left`    |
 | `symbol-chevron-right` | `.icon.icon-chevron-right`   |
+
+You can provide a `getIconId` function via the configuration file to customize how the icon IDs / CSS selectors are derived from the filepath. The function will receive relative paths to the icon and the input directory as arguments, and must return a unique string to be used as the ID.
 
 ### Contribute
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 import { RunnerOptions } from './types/runner';
 import { FontAssetType, OtherAssetType } from './types/misc';
+import { getIconId } from './utils/icon-id';
 
 export const TEMPLATES_DIR = resolve(__dirname, '../templates');
 
@@ -24,7 +25,8 @@ export const DEFAULT_OPTIONS: Omit<RunnerOptions, 'inputDir' | 'outputDir'> = {
   selector: null,
   tag: 'i',
   prefix: 'icon',
-  fontsUrl: undefined
+  fontsUrl: undefined,
+  getIconId: getIconId
 };
 
 export const DEFAULT_START_CODEPOINT = 0xf101;

--- a/src/core/__tests__/config-parser.ts
+++ b/src/core/__tests__/config-parser.ts
@@ -1,5 +1,6 @@
 import { parseConfig } from '../config-parser';
 import { checkPath } from '../../utils/fs-async';
+import { DEFAULT_OPTIONS } from '../../constants';
 
 const checkPathMock = (checkPath as any) as jest.Mock;
 
@@ -32,7 +33,8 @@ const mockConfig = {
     sass: 'sass',
     scss: 'scss',
     html: 'html'
-  }
+  },
+  getIconId: DEFAULT_OPTIONS.getIconId
 };
 
 const testError = async (options: object, key: string, message: string) =>
@@ -87,6 +89,7 @@ describe('Config parser', () => {
       'normalize',
       'must be a boolean value'
     );
+    await testError({ getIconId: true }, 'getIconId', 'true is not a function');
   });
 
   test('correctly validates existance of input and output paths', async () => {

--- a/src/core/__tests__/runner.ts
+++ b/src/core/__tests__/runner.ts
@@ -114,7 +114,11 @@ describe('Runner', () => {
     await generateFonts(optionsIn);
 
     expect(loadAssetsMock).toHaveBeenCalledTimes(1);
-    expect(loadAssetsMock).toHaveBeenCalledWith(inputDir);
+    expect(loadAssetsMock).toHaveBeenCalledWith({
+      ...DEFAULT_OPTIONS,
+      ...optionsIn,
+      parsed: true
+    });
   });
 
   test('`generateFonts` calls `getGeneratorOptions` correctly', async () => {

--- a/src/core/config-parser.ts
+++ b/src/core/config-parser.ts
@@ -4,6 +4,7 @@ import {
   parseDir,
   parseString,
   parseBoolean,
+  parseFunction,
   listMembersParser,
   parseNumeric,
   optional,
@@ -30,7 +31,8 @@ const CONFIG_VALIDATORS: {
   selector: [nullable(parseString)],
   tag: [parseString],
   prefix: [parseString],
-  fontsUrl: [optional(parseString)]
+  fontsUrl: [optional(parseString)],
+  getIconId: [optional(parseFunction)]
 };
 
 export const parseConfig = async (input: object = {}) => {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -41,7 +41,7 @@ export const generateFonts = async (
     throw new Error('You must specify an output directory');
   }
 
-  const assetsIn = await loadAssets(options.inputDir);
+  const assetsIn = await loadAssets(options);
   const generatorOptions = getGeneratorOptions(options, assetsIn);
   const assetsOut = await generateAssets(generatorOptions);
   const writeResults = outputDir ? await writeAssets(assetsOut, options) : [];

--- a/src/types/runner.ts
+++ b/src/types/runner.ts
@@ -23,6 +23,7 @@ export type RunnerOptionalOptions = {
   templates: { [key in OtherAssetType]?: string };
   prefix: string;
   fontsUrl: string;
+  getIconId: Function;
 };
 
 export type RunnerOptionsInput = RunnerMandatoryOptions &

--- a/src/utils/__tests__/assets.ts
+++ b/src/utils/__tests__/assets.ts
@@ -1,4 +1,5 @@
 import { loadPaths, loadAssets, writeAssets } from '../assets';
+import { DEFAULT_OPTIONS } from '../../constants';
 import { writeFile } from '../fs-async';
 
 const writeFileMock = (writeFile as any) as jest.Mock;
@@ -49,7 +50,13 @@ describe('Assets utilities', () => {
   });
 
   test('`loadAssets` resolves a key - value map of assets with expected properties', async () => {
-    expect(await loadAssets('./valid')).toEqual({
+    expect(
+      await loadAssets({
+        ...DEFAULT_OPTIONS,
+        inputDir: './valid',
+        outputDir: './output'
+      })
+    ).toEqual({
       foo: {
         relativePath: 'foo.svg',
         absolutePath: '/root/project/valid/foo.svg',
@@ -69,6 +76,35 @@ describe('Assets utilities', () => {
         relativePath: 'sub/sub/nested.svg',
         absolutePath: '/root/project/valid/sub/sub/nested.svg',
         id: 'sub-sub-nested'
+      }
+    });
+  });
+
+  test('`loadAssets` with a custom `getIconId` implementation resolves a key - value map of assets with expected properties', async () => {
+    expect(
+      await loadAssets({
+        ...DEFAULT_OPTIONS,
+        inputDir: './valid',
+        outputDir: './output',
+        getIconId: (relativeIconPath, relativeInputDir) => {
+          return relativeIconPath.split('/').pop().replace('.svg', '');
+        }
+      })
+    ).toEqual({
+      foo: {
+        relativePath: 'foo.svg',
+        absolutePath: '/root/project/valid/foo.svg',
+        id: 'foo'
+      },
+      bar: {
+        relativePath: 'bar.svg',
+        absolutePath: '/root/project/valid/bar.svg',
+        id: 'bar'
+      },
+      nested: {
+        relativePath: 'sub/sub/nested.svg',
+        absolutePath: '/root/project/valid/sub/sub/nested.svg',
+        id: 'nested'
       }
     });
   });

--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -1,7 +1,6 @@
 import glob from 'glob';
 import { promisify } from 'util';
 import { resolve, relative, join } from 'path';
-import { getIconId } from './icon-id';
 import { writeFile } from './fs-async';
 import { RunnerOptions } from '../types/runner';
 import { GeneratedAssets } from '../generators/generate-assets';
@@ -34,17 +33,20 @@ export const loadPaths = async (dir: string): Promise<string[]> => {
   return files;
 };
 
-export const loadAssets = async (dir: string): Promise<AssetsMap> => {
-  const paths = await loadPaths(dir);
+export const loadAssets = async ({
+  inputDir,
+  getIconId
+}: RunnerOptions): Promise<AssetsMap> => {
+  const paths = await loadPaths(inputDir);
   const out = {};
 
   for (const path of paths) {
-    const iconId = getIconId(path, dir);
+    const iconId = getIconId(path, inputDir);
 
     out[iconId] = {
       id: iconId,
       absolutePath: resolve(path),
-      relativePath: relative(resolve(dir), resolve(path))
+      relativePath: relative(resolve(inputDir), resolve(path))
     };
   }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -21,6 +21,14 @@ export const parseString = (value: string) => {
   return value;
 };
 
+export const parseFunction = (value: Function) => {
+  if (typeof value !== 'function') {
+    throw new Error(`${value} is not a function`);
+  }
+
+  return value;
+};
+
 export const listMembersParser = <T extends string>(allowedValues: T[]) => (
   values: string[]
 ) => {


### PR DESCRIPTION
:wave: thanks for creating this fun project!

**What is this?**

i've found myself wanting a bit more control over the icon class names (IDs) generated by `fantasticon`. i'd like to categorize my icons into different folders, but i don't want any folder names baked into the generated class names.

here's an idea for how we could address this– please let me know what you think when you've got a chance!

**Changes**

- adds a `getIconId` config option to facilitate customization of generated icon IDs, using the current implementation as the default value

**New functionality**

say we have the following `.fantasticonrc.js`:
```js
module.exports = {
  inputDir: './src',
  outputDir: './dist',
}
```
and the following `src/`:
```
src
├── features
│   ├── bluetooth.svg
│   └── toolbar
│       ├── battery-empty.svg
│       └── battery-full.svg
├── misc
│   └── cold.svg
└── umbrella.svg
```

`fantasticon` will produce the following icon output:
```html
<i class="icon icon-features-bluetooth"></i>
<i class="icon icon-features-toolbar-battery-empty"></i>
<i class="icon icon-features-toolbar-battery-full"></i>
<i class="icon icon-misc-cold"></i>
<i class="icon icon-umbrella"></i>
```

with the changes in this PR, we can add a few lines of code to the config file to customize how those icon class names are generated:

```diff
 module.exports = {
   inputDir: './src',
   outputDir: './dist',
+  getIconId: (relativeIconPath, inputDir) => {
+    return relativeIconPath
+      .split('/')
+      .pop()
+      .replace('.svg', '');
+  }
 }
```

which yields the following icon output:

```diff
-<i class="icon icon-features-bluetooth"></i>
-<i class="icon icon-features-toolbar-battery-empty"></i>
-<i class="icon icon-features-toolbar-battery-full"></i>
-<i class="icon icon-misc-cold"></i>
+<i class="icon icon-bluetooth"></i>
+<i class="icon icon-battery-empty"></i>
+<i class="icon icon-battery-full"></i>
+<i class="icon icon-cold"></i>
 <i class="icon icon-umbrella"></i>
```

**Alternative potential use case 1:**

- single directory sorting: https://github.com/tancredi/fantasticon/pull/106

here's the order of the icons generated from our previous step:

![unsorted-output](https://user-images.githubusercontent.com/81541018/112779153-b1629500-900b-11eb-9036-acfaf5cb0100.png)

we can lean on the sorting done by `glob` + prefixes on the icon filenames to indirectly support that use case.

e.g. the new `src/` directory:
```diff
src
├── 00-umbrella.svg
├── 01-cold.svg
├── 02-battery-full.svg
├── 03-battery-empty.svg
└── 04-bluetooth.svg
```

the new `getIconId` implementation:
```diff
module.exports = {
  inputDir: './src',
  outputDir: './dist',
  getIconId: (relativeIconPath, inputDir) => {
    return relativeIconPath.split('/')
      .pop()
-     .replace('.svg', '');
+     .replace('.svg', '')
+     .replace(/^[^a-z]+/i, '');
  }
}
```

the resulting ordering of icons:

![sorted-output](https://user-images.githubusercontent.com/81541018/112779166-b6274900-900b-11eb-9c1e-9a89da2ca2bf.png)

---

**Alternative potential use case 2:**

- folder structuring: https://github.com/tancredi/fantasticon/issues/177

(example given as comment in issue)

---

that's all – thanks for your time!