### PR TITLE
Fix to escape file name containing a quote

### DIFF
--- a/src/utils/icon-id.ts
+++ b/src/utils/icon-id.ts
@@ -5,7 +5,7 @@ import { removeExtension } from './path';
 export const getIconId = (filepath: string, root: string) =>
   slug(
     removeExtension(relative(resolve(root), resolve(filepath))).replace(
-      /(\/|\\|\.)+/g,
+      /(\/|\\|\.|\')+/g,
       '-'
     ),
     { replacement: '-' }


### PR DESCRIPTION
When a svg file name contains a quote (like "I'm-a-svg.svg" ,the html & css contains I&#x27;m-a-svg.svg and the icon is empty.

Added replacement for quote character