### PR TITLE
Remove duplicate glyphs in SVG output

### DIFF
--- a/src/generators/asset-types/__tests__/__snapshots__/svg.ts.snap
+++ b/src/generators/asset-types/__tests__/__snapshots__/svg.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`\`SVG\` font generator passes correctly format options to \`SVGIcons2SVGFontStream\` 1`] = `"processed->content->/root/foo.svg|{\\"name\\":\\"foo\\",\\"unicode\\":[\\"\\\\u0001\\"]}$processed->content->/root/bar.svg|{\\"name\\":\\"bar\\",\\"unicode\\":[\\"\\\\u0001\\"]}$"`;
+
+exports[`\`SVG\` font generator resolves with the result of the completed \`SVGIcons2SVGFontStream\` 1`] = `"processed->content->/root/foo.svg|{\\"name\\":\\"foo\\",\\"unicode\\":[\\"\\\\u0001\\"]}$processed->content->/root/bar.svg|{\\"name\\":\\"bar\\",\\"unicode\\":[\\"\\\\u0001\\"]}$"`;

--- a/src/generators/asset-types/__tests__/svg.ts
+++ b/src/generators/asset-types/__tests__/svg.ts
@@ -1,4 +1,4 @@
-import _SVGIcons2SVGFontStream from 'svgicons2svgfont';
+import * as _SVGIcons2SVGFontStream from 'svgicons2svgfont';
 import { FontAssetType } from '../../../types/misc';
 import { FontGeneratorOptions } from '../../../types/generator';
 import svgGen from '../svg';
@@ -21,7 +21,12 @@ jest.mock('svgicons2svgfont', () => {
     public content = '';
 
     public write(chunk: any) {
-      this.events.emit('data', Buffer.from(`processed->${chunk.content}$`));
+      this.events.emit(
+        'data',
+        Buffer.from(
+          `processed->${chunk.content}|${JSON.stringify(chunk.metadata)}$`
+        )
+      );
       return this;
     }
 
@@ -71,15 +76,15 @@ describe('`SVG` font generator', () => {
       __mock: 'options__'
     });
 
-    expect(result).toBe(
-      'processed->content->/root/foo.svg$processed->content->/root/bar.svg$'
-    );
+    expect(result).toMatchSnapshot();
   });
 
   test('passes correctly format options to `SVGIcons2SVGFontStream`', async () => {
     const log = () => null;
     const formatOptions = { descent: 5, fontHeight: 6, log };
-    await svgGen.generate(mockOptions(formatOptions), null);
+    const result = await svgGen.generate(mockOptions(formatOptions), null);
+
+    expect(result).toMatchSnapshot();
 
     expect(SVGIcons2SVGFontStream).toHaveBeenCalledTimes(1);
     expect(SVGIcons2SVGFontStream).toHaveBeenCalledWith({

--- a/src/generators/asset-types/svg.ts
+++ b/src/generators/asset-types/svg.ts
@@ -31,13 +31,8 @@ const generator: FontGenerator<void> = {
       for (const { id, absolutePath } of Object.values(assets)) {
         const glyph: GglyphStream = createReadStream(absolutePath);
         const unicode = String.fromCharCode(codepoints[id]);
-        let ligature = '';
 
-        for (let i = 0; i < id.length; i++) {
-          ligature += String.fromCharCode(id.charCodeAt(i));
-        }
-
-        glyph.metadata = { name: id, unicode: [unicode, ligature] };
+        glyph.metadata = { name: id, unicode: [unicode] };
 
         fontStream.write(glyph);
       }


### PR DESCRIPTION
Remove duplicate SVG glyphs by not passing the icon ID as a unicode option

Add snapshot tests for SVG, just to ensure whatever is provided to the SVG font library is somehow locked

Issue was introduced by porting https://github.com/sunflowerdeath/webfonts-generator/blob/master/src/generateFonts.js#L50 which was adding a ligature taken by the icon name as a unicode point - not sure why or what made it behave differently in this repo

Should address https://github.com/tancredi/fantasticon/issues/154