### PR TITLE
feat: add fontsUrlHash to prevent adding extra hash parameters to url function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ yarn-error.log
 
 # Build
 lib
+
+# Jetbrains
+.idea

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ generateFonts({
   selector: null,
   tag: 'i',
   prefix: 'icon',
-  fontsUrl: null
+  fontsUrl: null,
+  fontsUrlHash: true, // default is true
 }).then(results => console.log(results));
 ```
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const DEFAULT_OPTIONS: Omit<RunnerOptions, 'inputDir' | 'outputDir'> = {
   tag: 'i',
   prefix: 'icon',
   fontsUrl: undefined,
+  fontsUrlHash: true,
   getIconId: getIconId
 };
 

--- a/src/core/config-parser.ts
+++ b/src/core/config-parser.ts
@@ -32,6 +32,7 @@ const CONFIG_VALIDATORS: {
   tag: [parseString],
   prefix: [parseString],
   fontsUrl: [optional(parseString)],
+  fontsUrlHash: [optional(parseBoolean)],
   getIconId: [optional(parseFunction)]
 };
 

--- a/src/types/runner.ts
+++ b/src/types/runner.ts
@@ -23,6 +23,7 @@ export type RunnerOptionalOptions = {
   templates: { [key in OtherAssetType]?: string };
   prefix: string;
   fontsUrl: string;
+  fontsUrlHash: boolean;
   getIconId: GetIconIdFn;
 };
 

--- a/src/utils/__tests__/css.ts
+++ b/src/utils/__tests__/css.ts
@@ -74,5 +74,21 @@ describe('CSS utilities', () => {
         'url("https://my-static.com/my-font.ttf?::hashed(::font-content::)::") format("truetype")'
       );
     });
+
+    it('render src with disabled fontsUrlHash option', () => {
+      const font = '::font-content::';
+      const options = {
+        fontTypes: [FontAssetType.WOFF, FontAssetType.WOFF2],
+        name: 'my-font',
+        fontsUrlHash: false,
+      };
+
+      expect(renderSrcAttribute(options as any, font)).toEqual(
+        [
+          'url("./my-font.woff?") format("woff"),',
+          'url("./my-font.woff2?") format("woff2")'
+        ].join('\n')
+      );
+    });
   });
 });

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -19,13 +19,13 @@ const renderSrcOptions: { [key in FontAssetType]: RenderSrcOptions } = {
 };
 
 export const renderSrcAttribute = (
-  { name, fontTypes, fontsUrl }: FontGeneratorOptions,
+  { name, fontTypes, fontsUrl, fontsUrlHash = true }: FontGeneratorOptions,
   font: string | Buffer
 ) =>
   fontTypes
     .map(fontType => {
       const { formatValue, getSuffix } = renderSrcOptions[fontType];
-      const hash = getHash(font.toString('utf8'));
+      const hash = fontsUrlHash ? getHash(font.toString('utf8')): '';
       const suffix = getSuffix ? getSuffix(name) : '';
       return `url("${
         fontsUrl || '.'


### PR DESCRIPTION
This is very useful when a developer wants to build icons through webpack build process or git hooks and commit output. 
But in the current state of repository developers cant prevent adding hash parameters to the output css or scss file and on each running of build that parameters will change and developer should be carefull about that changes and revert them. So this is annoying.

`@font-face {
  font-family: $icons-font;
  src: url('./icon-font.woff2') format('woff2'),
    url('./icon-font.woff') format('woff');
}`