### PR TITLE
Enable placeholder usage within Sass & SCSS templates

### DIFF
--- a/src/generators/asset-types/__tests__/__snapshots__/sass.ts.snap
+++ b/src/generators/asset-types/__tests__/__snapshots__/sass.ts.snap
@@ -7,7 +7,7 @@ exports[`\`SASS\` asset generator renders SASS correctly with \`selector\` optio
     font-family: $test-font
     src: \\"::src-attr::\\"
 
-.my-selector:before
+%test-font-style
     font-family: test !important
     font-style: normal
     font-weight: normal !important
@@ -16,6 +16,9 @@ exports[`\`SASS\` asset generator renders SASS correctly with \`selector\` optio
     line-height: 1
     -webkit-font-smoothing: antialiased
     -moz-osx-font-smoothing: grayscale
+
+.my-selector:before
+    @extend %test-font-style
 
 
 $test-map: (
@@ -34,7 +37,7 @@ exports[`\`SASS\` asset generator renders SASS correctly with prefix and tag nam
     font-family: $test-font
     src: \\"::src-attr::\\"
 
-b[class^=\\"tf-\\"]:before, b[class*=\\" tf-\\"]:before
+%test-font-style
     font-family: test !important
     font-style: normal
     font-weight: normal !important
@@ -43,6 +46,9 @@ b[class^=\\"tf-\\"]:before, b[class*=\\" tf-\\"]:before
     line-height: 1
     -webkit-font-smoothing: antialiased
     -moz-osx-font-smoothing: grayscale
+
+b[class^=\\"tf-\\"]:before, b[class*=\\" tf-\\"]:before
+    @extend %test-font-style
 
 
 $test-map: (

--- a/src/generators/asset-types/__tests__/__snapshots__/scss.ts.snap
+++ b/src/generators/asset-types/__tests__/__snapshots__/scss.ts.snap
@@ -8,7 +8,7 @@ exports[`\`SCSS\` asset generator renders SCSS correctly with \`selector\` optio
     src: \\"::src-attr::\\";
 }
 
-.my-selector:before {
+%test-font-style {
     font-family: test !important;
     font-style: normal;
     font-weight: normal !important;
@@ -17,6 +17,10 @@ exports[`\`SCSS\` asset generator renders SCSS correctly with \`selector\` optio
     line-height: 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+.my-selector:before {
+    @extend %test-font-style;
 }
 
 $test-map: (
@@ -37,7 +41,7 @@ exports[`\`SCSS\` asset generator renders SCSS correctly with prefix and tag nam
     src: \\"::src-attr::\\";
 }
 
-b[class^=\\"tf-\\"]:before, b[class*=\\" tf-\\"]:before {
+%test-font-style {
     font-family: test !important;
     font-style: normal;
     font-weight: normal !important;
@@ -46,6 +50,10 @@ b[class^=\\"tf-\\"]:before, b[class*=\\" tf-\\"]:before {
     line-height: 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+b[class^=\\"tf-\\"]:before, b[class*=\\" tf-\\"]:before {
+    @extend %test-font-style;
 }
 
 $test-map: (

--- a/templates/sass.hbs
+++ b/templates/sass.hbs
@@ -4,11 +4,7 @@ ${{ name }}-font: "{{ name }}"
     font-family: ${{ name }}-font
     src: {{{ fontSrc }}}
 
-{{# if selector }}
-{{ selector }}:before
-{{ else }}
-{{ tag }}[class^="{{prefix}}-"]:before, {{ tag }}[class*=" {{prefix}}-"]:before
-{{/ if }}
+%{{ name }}-font-style
     font-family: {{ name }} !important
     font-style: normal
     font-weight: normal !important
@@ -17,6 +13,13 @@ ${{ name }}-font: "{{ name }}"
     line-height: 1
     -webkit-font-smoothing: antialiased
     -moz-osx-font-smoothing: grayscale
+
+{{# if selector }}
+{{ selector }}:before
+{{ else }}
+{{ tag }}[class^="{{prefix}}-"]:before, {{ tag }}[class*=" {{prefix}}-"]:before
+{{/ if }}
+    @extend %{{ name }}-font-style
 
 
 ${{ name }}-map: (

--- a/templates/scss.hbs
+++ b/templates/scss.hbs
@@ -5,11 +5,7 @@ ${{ name }}-font: "{{ name }}";
     src: {{{ fontSrc }}};
 }
 
-{{# if selector }}
-{{ selector }}:before {
-{{ else }}
-{{ tag }}[class^="{{prefix}}-"]:before, {{ tag }}[class*=" {{prefix}}-"]:before {
-{{/ if }}
+%{{ name }}-font-style {
     font-family: {{ name }} !important;
     font-style: normal;
     font-weight: normal !important;
@@ -18,6 +14,14 @@ ${{ name }}-font: "{{ name }}";
     line-height: 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+{{# if selector }}
+{{ selector }}:before {
+{{ else }}
+{{ tag }}[class^="{{prefix}}-"]:before, {{ tag }}[class*=" {{prefix}}-"]:before {
+{{/ if }}
+    @extend %{{ name }}-font-style;
 }
 
 ${{ name }}-map: (


### PR DESCRIPTION
A small change that allows us to use the icon-font styling as a placeholder within Sass & SCSS templates so it can be easily extended. For example: elements that are maintained externally (in an extension or a plugin) and are not changeable (regarding HTML structure).

As an example (using SCSS template):
```
.element-of-extension {
  &:before {
    @extend %[base name]-font-style; // extends all the necessary icon-font styling
    @extend .[prefix]-[icon name]; // extends specific icon
  }
}
```