### PR TITLE
ver 2.0.0 no SVGs found #471

### DIFF
--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -23,8 +23,8 @@ export interface AssetsMap {
 export const ASSETS_EXTENSION = 'svg';
 
 export const loadPaths = async (dir: string): Promise<string[]> => {
-  const globPath = join(dir, `**/*.${ASSETS_EXTENSION}`);
-
+  // glob has issues with windows separators, so we need to replace them
+  const globPath = join(dir, `**/*.${ASSETS_EXTENSION}`).replace(/\\/g,'/');
   const files = await promisify(glob)(globPath, {});
 
   if (!files.length) {


### PR DESCRIPTION
It seems that the `glob` package has some problems with Windows separators (`\`) so let's replace them with unix separators (`/`) before running the glob command. It seems that it fixes the "No SVGs found" error on Windows.