### PR TITLE
fix: glob directory issue - SVGs not found

### DIFF
--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -23,7 +23,7 @@ export interface AssetsMap {
 export const ASSETS_EXTENSION = 'svg';
 
 export const loadPaths = async (dir: string): Promise<string[]> => {
-  const globPath = join(dir, `**/*.${ASSETS_EXTENSION}`);
+  const globPath = join(dir, `**/*.${ASSETS_EXTENSION}`).replace(/\\/g,'/');
 
   const files = await promisify(glob)(globPath, {});
 


### PR DESCRIPTION
Newest version of `glob` causes issues with directories.
Adding `.replace(/\\/g,'/')` to the end of the `globPath` fixes this issue
PR fixes: #470 and #471 