### PR TITLE
chore(html): css relative path

### DIFF
--- a/templates/html.hbs
+++ b/templates/html.hbs
@@ -49,7 +49,7 @@
         }
     </style>
 
-    <link rel="stylesheet" type="text/css" href="{{ name }}.css" />
+    <link rel="stylesheet" type="text/css" href="./{{ name }}.css" />
 </head>
 <body>
 


### PR DESCRIPTION
Using the relative path of the css file because it's in the same folder as the html, this makes it possible to put the files in any folder, not just the root of the domain