### PR TITLE
BREAKING CHANGE: Add support note in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ And the generated icon IDs would be:
 
 You can provide a `getIconId` function via the configuration file to customize how the icon IDs / CSS selectors are derived from the filepath. The function will receive relative paths to the icon and the input directory as arguments, and must return a unique string to be used as the ID.
 
+### Support
+
+The library is currently actively maintained for for Node 16.x.x support or above
+
 ### Contribute
 
 PRs are always welcome. If you need help questions, want to bounce ideas or just say hi, [join the Discord channel](https://discord.gg/BXAY3Kc3mp).


### PR DESCRIPTION
BREAKING CHANGE: Lower support - now only Node.js >= 16.x.x
- Upgrade `glob` - used as named export and Promise, change test mocks accordingly
- Replace `change-case` module to `case` to avoid issues related to mixing pure ESM modules and CommonJS
- Update CI test matrix
- Add `fix` script to write `prettier` fixes
- Update formatting after `prettier` upgrade