### PR TITLE
Vertically align middle with the generated styles

### DIFF
--- a/templates/css.hbs
+++ b/templates/css.hbs
@@ -14,6 +14,7 @@
     font-variant: normal;
     text-transform: none;
     line-height: 1;
+    vertical-align: middle;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }

--- a/templates/sass.hbs
+++ b/templates/sass.hbs
@@ -15,6 +15,7 @@ ${{ name }}-font: "{{ name }}"
     font-variant: normal
     text-transform: none
     line-height: 1
+    vertical-align: middle
     -webkit-font-smoothing: antialiased
     -moz-osx-font-smoothing: grayscale
 

--- a/templates/scss.hbs
+++ b/templates/scss.hbs
@@ -16,6 +16,7 @@ ${{ name }}-font: "{{ name }}";
     font-variant: normal;
     text-transform: none;
     line-height: 1;
+    vertical-align: middle;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION

```css
vertical-align: middle;
```

Adding vertical-align middle to `css`, `scss`, and `sass` handlebars templates. 
Adding this lets the icon align with adjacent text. See screenshots of before and after below. 

 **Before:**
<img width="529" alt="Screenshot 2025-02-05 at 2 10 51 PM" src="https://github.com/user-attachments/assets/1de5cccc-8e3b-414b-822e-0cc949e48ad0" />

**After:**
<img width="466" alt="Screenshot 2025-02-05 at 2 10 03 PM" src="https://github.com/user-attachments/assets/34eb8852-2936-4564-9aff-1fe745604ebc" />


