### PR TITLE
fix: update map function in scss.hbs

### DIFF
--- a/templates/scss.hbs
+++ b/templates/scss.hbs
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 ${{ name }}-font: "{{ name }}";
 
 @font-face {
@@ -32,6 +34,6 @@ ${{ name }}-map: (
 {{ else }}
 {{ tag }}.{{ ../prefix }}-{{ @key }}:before {
 {{/ if }}
-    content: map-get(${{ ../name }}-map, "{{ @key }}");
+    content: map.get(${{ ../name }}-map, "{{ @key }}");
 }
 {{/ each }}


### PR DESCRIPTION
Hi!

I noticed that the scss generation using sass 1.85.0 seems to be failing. According to the Heads Up in this document the `map-get()` function has become deprecated in due to the switch to the new import system. Unfortunately was not able to determine when this came into effect 🤷‍♂️ 

Making the changes in this PR resolved the issue for me. Thought it would be helpful for others as well :)

For any troubled developers reading this, know that you can take advantage of these changes without forking the library with the handy-dandy `templates` option! Just copy the `scss.hbs` file to your repo, add this PRs' changes to it and point to it using the templates option in the fantasticon config. Like so:
```
module.exports = {
   ...
   templates: {
     scss: 'path/to/map-get-fix-template.scss.hbs'
   },
   ...
}
```