### PR TITLE
fix: order assets ascending [#550]

### DIFF
--- a/src/utils/__tests__/assets.ts
+++ b/src/utils/__tests__/assets.ts
@@ -33,8 +33,8 @@ describe('Assets utilities', () => {
 
     it('resolves an Array of the correct filepaths within the given directory', async () => {
       expect(await loadPaths('./valid')).toEqual([
-        '/project/valid/foo.svg',
         '/project/valid/bar.svg',
+        '/project/valid/foo.svg',
         '/project/valid/sub/nested.svg',
         '/project/valid/sub/sub/nested.svg'
       ]);
@@ -101,15 +101,15 @@ describe('Assets utilities', () => {
           getIconId
         })
       ).toEqual({
-        '0_foo': {
-          relativePath: 'foo.svg',
-          absolutePath: '/root/project/valid/foo.svg',
-          id: '0_foo'
-        },
-        '1_bar': {
+        '0_bar': {
           relativePath: 'bar.svg',
           absolutePath: '/root/project/valid/bar.svg',
-          id: '1_bar'
+          id: '0_bar'
+        },
+        '1_foo': {
+          relativePath: 'foo.svg',
+          absolutePath: '/root/project/valid/foo.svg',
+          id: '1_foo'
         },
         '2_sub_nested': {
           relativePath: 'sub/nested.svg',
@@ -126,10 +126,10 @@ describe('Assets utilities', () => {
       expect(getIconId).toHaveBeenCalledTimes(4);
 
       expect(getIconId).toHaveBeenNthCalledWith(1, {
-        basename: 'foo',
+        basename: 'bar',
         relativeDirPath: '',
-        absoluteFilePath: '/root/project/valid/foo.svg',
-        relativeFilePath: 'foo.svg',
+        absoluteFilePath: '/root/project/valid/bar.svg',
+        relativeFilePath: 'bar.svg',
         index: 0
       });
 
@@ -154,7 +154,7 @@ describe('Assets utilities', () => {
         })
       ).rejects.toEqual(
         new Error(
-          "Conflicting result from 'getIconId': 'xxx' - conflicting input files:\n  - foo.svg\n  - bar.svg"
+          "Conflicting result from 'getIconId': 'xxx' - conflicting input files:\n  - bar.svg\n  - foo.svg"
         )
       );
     });

--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -23,7 +23,7 @@ export const ASSETS_EXTENSION = 'svg';
 
 export const loadPaths = async (dir: string): Promise<string[]> => {
   const globPath = join(dir, `**/*.${ASSETS_EXTENSION}`);
-  const files = await glob(globPath, {});
+  const files = (await glob(globPath, {})).sort((a, b) => a.localeCompare(b));
 
   if (!files.length) {
     throw new Error(`No SVGs found in ${dir}`);


### PR DESCRIPTION
with the update to 3.0.0 the order got inversed due to changes in glob (see https://github.com/tancredi/fantasticon/issues/550#issuecomment-2722207603)
