### PR TITLE
Feature/#601 Sass: map-get is Deprecated

### DIFF
--- a/src/generators/asset-types/__tests__/__snapshots__/sass.ts.snap
+++ b/src/generators/asset-types/__tests__/__snapshots__/sass.ts.snap
@@ -17,13 +17,13 @@ exports[`\`SASS\` asset generator renders SASS correctly with \`selector\` optio
     -webkit-font-smoothing: antialiased
     -moz-osx-font-smoothing: grayscale
 
-
 $test-map: (
     "my-icon": "\\f101",
 )
 
-.my-selector.tf-my-icon:before
-    content: map-get($test-map, "my-icon")
+@each $name, $value in ($test-map)
+    .my-selector.tf-#{$name}:before
+        content: $value
 "
 `;
 
@@ -44,12 +44,12 @@ b[class^="tf-"]:before, b[class*=" tf-"]:before
     -webkit-font-smoothing: antialiased
     -moz-osx-font-smoothing: grayscale
 
-
 $test-map: (
     "my-icon": "\\f101",
 )
 
-.tf-my-icon:before
-    content: map-get($test-map, "my-icon")
+@each $name, $value in ($test-map)
+    b.tf-#{$name}:before
+        content: $value
 "
 `;

--- a/src/generators/asset-types/__tests__/__snapshots__/sass.ts.snap
+++ b/src/generators/asset-types/__tests__/__snapshots__/sass.ts.snap
@@ -49,7 +49,7 @@ $test-map: (
 )
 
 @each $name, $value in ($test-map)
-    b.tf-#{$name}:before
+    .tf-#{$name}:before
         content: $value
 "
 `;

--- a/src/generators/asset-types/__tests__/__snapshots__/scss.ts.snap
+++ b/src/generators/asset-types/__tests__/__snapshots__/scss.ts.snap
@@ -23,8 +23,10 @@ $test-map: (
     "my-icon": "\\f101",
 );
 
-.my-selector.tf-my-icon:before {
-    content: map-get($test-map, "my-icon");
+@each $name, $value in ($test-map) {
+    .my-selector.tf-#{$name}:before {
+        content: $value;
+    }
 }
 "
 `;
@@ -52,8 +54,10 @@ $test-map: (
     "my-icon": "\\f101",
 );
 
-.tf-my-icon:before {
-    content: map-get($test-map, "my-icon");
+@each $name, $value in ($test-map) {
+    b.tf-#{$name}:before {
+        content: $value;
+    }
 }
 "
 `;

--- a/src/generators/asset-types/__tests__/__snapshots__/scss.ts.snap
+++ b/src/generators/asset-types/__tests__/__snapshots__/scss.ts.snap
@@ -55,7 +55,7 @@ $test-map: (
 );
 
 @each $name, $value in ($test-map) {
-    b.tf-#{$name}:before {
+    .tf-#{$name}:before {
         content: $value;
     }
 }

--- a/src/generators/asset-types/__tests__/sass.ts
+++ b/src/generators/asset-types/__tests__/sass.ts
@@ -53,7 +53,7 @@ describe('`SASS` asset generator', () => {
     const sass = await sassGen.generate(mockOptions, Buffer.from(''));
 
     expect(sass).toContain('b[class^="tf-"]:before, b[class*=" tf-"]:before');
-    expect(sass).toContain('.tf-my-icon:before');
+    expect(sass).toContain('.tf-#{$name}:before');
   });
 
   test('renders expected variables', async () => {
@@ -70,6 +70,6 @@ describe('`SASS` asset generator', () => {
     );
 
     expect(sass).toContain('.my-selector:before');
-    expect(sass).toContain('.my-selector.tf-my-icon:before');
+    expect(sass).toContain('.my-selector.tf-#{$name}:before');
   });
 });

--- a/src/generators/asset-types/__tests__/scss.ts
+++ b/src/generators/asset-types/__tests__/scss.ts
@@ -53,7 +53,7 @@ describe('`SCSS` asset generator', () => {
     const scss = await scssGen.generate(mockOptions, Buffer.from(''));
 
     expect(scss).toContain('b[class^="tf-"]:before, b[class*=" tf-"]:before {');
-    expect(scss).toContain('.tf-my-icon:before {');
+    expect(scss).toContain('.tf-#{$name}:before {');
   });
 
   test('renders expected variables', async () => {
@@ -70,6 +70,6 @@ describe('`SCSS` asset generator', () => {
     );
 
     expect(scss).toContain('.my-selector:before {');
-    expect(scss).toContain('.my-selector.tf-my-icon:before {');
+    expect(scss).toContain('.my-selector.tf-#{$name}:before {');
   });
 });

--- a/templates/css.hbs
+++ b/templates/css.hbs
@@ -22,7 +22,7 @@
 {{# if ../selector }}
 {{ ../selector }}.{{ ../prefix }}-{{ @key }}:before {
 {{ else }}
-{{ tag }}.{{ ../prefix }}-{{ @key }}:before {
+.{{ ../prefix }}-{{ @key }}:before {
 {{/ if }}
     content: "\\{{ codepoint this }}";
 }

--- a/templates/sass.hbs
+++ b/templates/sass.hbs
@@ -18,18 +18,16 @@ ${{ name }}-font: "{{ name }}"
     -webkit-font-smoothing: antialiased
     -moz-osx-font-smoothing: grayscale
 
-
 ${{ name }}-map: (
 {{# each codepoints }}
     "{{ @key }}": "\\{{ codepoint this }}",
 {{/ each }}
 )
 
-{{# each codepoints }}
-{{# if ../selector }}
-{{ ../selector }}.{{ ../prefix }}-{{ @key }}:before
-{{ else }}
-{{ tag }}.{{ ../prefix }}-{{ @key }}:before
-{{/ if }}
-    content: map-get(${{ ../name }}-map, "{{ @key }}")
-{{/ each }}
+@each $name, $value in (${{ name }}-map)
+    {{# if selector }}
+    {{ selector }}.{{ prefix }}-#{$name}:before
+    {{ else }}
+    {{ tag }}.{{ prefix }}-#{$name}:before
+    {{/ if }}
+        content: $value

--- a/templates/sass.hbs
+++ b/templates/sass.hbs
@@ -28,6 +28,6 @@ ${{ name }}-map: (
     {{# if selector }}
     {{ selector }}.{{ prefix }}-#{$name}:before
     {{ else }}
-    {{ tag }}.{{ prefix }}-#{$name}:before
+    .{{ prefix }}-#{$name}:before
     {{/ if }}
         content: $value

--- a/templates/scss.hbs
+++ b/templates/scss.hbs
@@ -30,7 +30,7 @@ ${{ name }}-map: (
     {{# if selector }}
     {{ selector }}.{{ prefix }}-#{$name}:before {
     {{ else }}
-    {{ tag }}.{{ prefix }}-#{$name}:before {
+    .{{ prefix }}-#{$name}:before {
     {{/ if }}
         content: $value;
     }

--- a/templates/scss.hbs
+++ b/templates/scss.hbs
@@ -26,12 +26,12 @@ ${{ name }}-map: (
 {{/ each }}
 );
 
-{{# each codepoints }}
-{{# if ../selector }}
-{{ ../selector }}.{{ ../prefix }}-{{ @key }}:before {
-{{ else }}
-{{ tag }}.{{ ../prefix }}-{{ @key }}:before {
-{{/ if }}
-    content: map-get(${{ ../name }}-map, "{{ @key }}");
+@each $name, $value in (${{ name }}-map) {
+    {{# if selector }}
+    {{ selector }}.{{ prefix }}-#{$name}:before {
+    {{ else }}
+    {{ tag }}.{{ prefix }}-#{$name}:before {
+    {{/ if }}
+        content: $value;
+    }
 }
-{{/ each }}


### PR DESCRIPTION
- Updated handlebars for sass and scss to output an @each instead of looping in handlebars itself
- Updated the tests for the sass and scss

closes #601 