### PR TITLE
fix: use glob windowsPathsNoEscape for Windows compatibility

### DIFF
--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -23,7 +23,7 @@ export const ASSETS_EXTENSION = 'svg';
 
 export const loadPaths = async (dir: string): Promise<string[]> => {
   const globPath = join(dir, `**/*.${ASSETS_EXTENSION}`);
-  const files = await glob(globPath, {});
+  const files = await glob(globPath, { windowsPathsNoEscape: true, posix: true });
 
   if (!files.length) {
     throw new Error(`No SVGs found in ${dir}`);


### PR DESCRIPTION
## Summary

Fixes Windows compatibility issue where `glob` fails to find SVG files due to backslash path separators.

## Prior Art

This fix builds on the work already done by the community:

- **@OG-Jons** — [#510](https://github.com/tancredi/fantasticon/pull/510) (Feb 2023) — first identified the fix
- **@deyan-koba-zupit** — [#548](https://github.com/tancredi/fantasticon/pull/548) (Apr 2024) — updated the fix for newer codebase
- **@nicolo-ribaudo**, **@alexandermalcin**, **@GNUGradyn**, **@izbushka**, **@denissonleal**, **@eternalsolar**, **@AndriiSiuta**, **@nopeless**, **@brunnerh** and others who reported, confirmed, and advocated for the fix in [#470](https://github.com/tancredi/fantasticon/issues/470)

Both #510 and #548 proposed manually replacing backslashes with `.replace(/\\/g, '/')`. This PR takes a different approach using glob's built-in API.

## Problem

On Windows, `path.join()` produces backslashes (`C:\path\to\icons\**\*.svg`). Since glob v8, backslashes are interpreted as **escape characters**, not path separators — causing the "No SVGs found" error even when SVG files exist.

## Solution

Use glob's built-in [`windowsPathsNoEscape`](https://github.com/isaacs/node-glob#windowspathsnoescape) and `posix` options:

```typescript
const files = await glob(globPath, { windowsPathsNoEscape: true, posix: true });
```

- **`windowsPathsNoEscape`** — treats `\` as path separators instead of escape characters in the glob pattern. No-op on Unix.
- **`posix`** — normalizes returned file paths to use forward slashes, ensuring consistent paths for downstream consumers like custom `getIconId` callbacks.

### Why this over `.replace(/\\/g, '/')`

The manual replacement in #510 and #548 fixes the input pattern, but returned paths from glob still contain backslashes on Windows. The `posix` option fixes both directions. Using the official API is also more resilient to future glob changes.

## Related Issues

- Fixes #470
- Fixes #471
- Duplicates #510 (now has merge conflicts with v4.x)
- Duplicates #548 (mergeable, uses manual string replacement)

## Testing

- All 176 existing tests pass
- Tested on Windows 11 with Node.js 22+